### PR TITLE
Untangle VERSION resource from test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [T.B.D] - yyyy-mm-dd
+- **Quality of life**
+  - Bumping the project's version through `VERSION` resource will not require changes in test cases
+
 ## [0.1.1] -  2021-02-26
 - **Packaging Fix**
     - Include `VERSION` resource in package, fixing `FileNotFoundError`

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,3 +8,4 @@ pytest-cov==2.11.1
 pytest-django==3.8.0
 pytest==6.2.2
 requests_mock==1.8.0
+testfixtures==6.17.1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from urllib.parse import urlencode
 
 import pytest
@@ -14,13 +15,20 @@ def mock_requests():
         yield mocker
 
 
+@pytest.fixture
+def mock_version():
+    with mock.patch("django_json_api.client.__version__") as mock_context:
+        mock_context.__str__ = lambda _: "0.1.2"
+        yield mock_context
+
+
 @override_settings(DJANGO_JSON_API_ADDITIONAL_HEADERS={})
-def test_jsonapi_client_session_headers():
+def test_jsonapi_client_session_headers(mock_version):
     del settings.DJANGO_JSON_API_ADDITIONAL_HEADERS
     client = JSONAPIClient()
     assert client.session.headers["Accept"] == "application/vnd.api+json"
     assert client.session.headers["Content-Type"] == "application/vnd.api+json"
-    assert client.session.headers["User-Agent"] == "JSONAPIClient/0.1.1"
+    assert client.session.headers["User-Agent"] == "JSONAPIClient/0.1.2"
 
     setattr(
         settings,

--- a/tests/test_django_json_api.py
+++ b/tests/test_django_json_api.py
@@ -1,5 +1,0 @@
-from django_json_api import __version__ as django_json_api_version
-
-
-def test_version() -> None:
-    assert django_json_api_version == "0.1.1"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,29 @@
+import os
+from typing import Generator
+from unittest import mock
+
+import pytest
+from testfixtures import TempDirectory
+
+from django_json_api.version import version
+
+
+@pytest.fixture
+def temp_dir() -> Generator[TempDirectory, None, None]:
+    with TempDirectory() as temp_dir:
+        yield temp_dir
+
+
+@pytest.fixture
+def version_file(temp_dir: TempDirectory) -> Generator[mock.Mock, None, None]:
+    version_file_content: bytes = b"0.1.2\n"
+    version_file_name: str = "VERSION"
+
+    with mock.patch("django_json_api.version.join") as mock_context:
+        temp_dir.write(version_file_name, version_file_content)
+        mock_context.return_value = os.path.join(temp_dir.path, version_file_name)
+        yield mock_context
+
+
+def test_version(version_file: mock.Mock) -> None:
+    assert version() == "0.1.2"


### PR DESCRIPTION
### Status
**READY**

### Background context
Two test cases required a small change whenever we bumped the project's version.

### Description of changes
Using `unittest.mock` I was able to untangle the test cases from the actual resource file, which will be changing frequently.

### Checklist

- [X] I provided a detailed description of the change, including motivations and implementation details
- [X] I have performed a self-review of my own code
- [X] I implemented unit tests for all new or modified behaviours
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation, CHANGELOG and VERSION (release to be done in the future)
