### PR TITLE
Upgraded djangorestframework-jsonapi to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [T.B.D] - yyyy-mm-dd
 - **Quality of life**
   - Bumping the project's version through `VERSION` resource will not require changes in test cases
+- **Requirements Changes**
+  - djangorestframework -> 3.12.2
+  - djangorestframework-jsonapi -> 4.1.0
 
 ## [0.1.1] -  2021-02-26
 - **Packaging Fix**

--- a/django_json_api/rest_framework.py
+++ b/django_json_api/rest_framework.py
@@ -51,9 +51,7 @@ def get_default_relation_serializer(json_api_model, only_fields=None):
                     )(read_only=True)
             return new_class
 
-    class _Serializer(
-        serializers.SparseFieldsetsMixin, serializers.Serializer, metaclass=_Metaclass
-    ):
+    class _Serializer(serializers.Serializer, metaclass=_Metaclass):
         class JSONAPIMeta:
             resource_name = json_api_model._meta.resource_type
             model = json_api_model

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-djangorestframework-jsonapi==3.1.0
-djangorestframework==3.11.0
+djangorestframework-jsonapi==4.1.0
+djangorestframework==3.12.2
 python-dateutil==2.7.5


### PR DESCRIPTION
### Instructions

This Pull Request upgrades djangorestframework-jsonapi to 4.1.0 (and djangorestframework to 3.12.2)

### Status
**READY**

### Background context
<!--
  Please provide the motivation for why this change is necessary at this stage of the product development cycle.
-->

This is a requirement to be used by Django 3.1 and later versions.

In particular, this allow upgrading to later versions of Django to avoid:
* https://github.com/advisories/GHSA-m6gj-h9gm-gw44
* https://github.com/advisories/GHSA-fr28-569j-53c4
* https://github.com/advisories/GHSA-fvgf-6h6h-3322

### Description of changes
<!--
  Please include a summary of the change and which issue is fixed.
-->

* upgrades djangorestframework-jsonapi to 4.1.0
* upgrades djangorestframework to 3.12.2
* rest_framework_json_api.serializers.Serializer now inherits from rest_framework_json_api.serializers.SparseFieldsetsMixin, so _Serializer does not need to inherit from it as well.

### Checklist

- [x] I provided a detailed description of the change, including motivations and implementation details
- [x] I have performed a self-review of my own code
- [ ] I implemented unit tests for all new or modified behaviours
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, CHANGELOG and VERSION
